### PR TITLE
Panshul names

### DIFF
--- a/src/main/java/de/votesapp/commands/plugins/NameCommentPlugin.java
+++ b/src/main/java/de/votesapp/commands/plugins/NameCommentPlugin.java
@@ -12,7 +12,7 @@ import de.votesapp.groups.Group;
 
 public class NameCommentPlugin implements CommandPlugin
 {
-    private Pattern pattern = Pattern.compile("^comment \\w+$");
+    private Pattern pattern = Pattern.compile("^comment \\w+$",Pattern.CASE_INSENSITIVE);
 
     @Override public Optional<Answer> interpret(GroupMessage message, Group group)
     {

--- a/src/main/java/de/votesapp/commands/plugins/NameCommentPlugin.java
+++ b/src/main/java/de/votesapp/commands/plugins/NameCommentPlugin.java
@@ -1,0 +1,37 @@
+package de.votesapp.commands.plugins;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.web.client.RestTemplate;
+
+import de.votesapp.client.GroupMessage;
+import de.votesapp.commands.CommandPlugin;
+import de.votesapp.groups.Group;
+
+public class NameCommentPlugin implements CommandPlugin
+{
+    private Pattern pattern = Pattern.compile("^comment \\w+$");
+
+    @Override public Optional<Answer> interpret(GroupMessage message, Group group)
+    {
+        Matcher matcher = pattern.matcher(message.normalizedText());
+        if (matcher.matches())
+        {
+            return Optional.of(Answer.intoGroup(group, fetchNewComment(message)));
+        }
+        return Optional.empty();
+    }
+
+    public String fetchNewComment(GroupMessage message)
+    {
+        String noun = message.normalizedText().split(" ")[1];
+        final RestTemplate restTemplate = new RestTemplate();
+        final String response = restTemplate.getForObject("http://nickserve42.appspot.com/forname/" + noun, String.class);
+        return String.format("%s says: %s", message.getSenderName(), response);
+    }
+}
+
+
+

--- a/src/test/java/de/votesapp/commands/plugins/NameCommentPluginTest.java
+++ b/src/test/java/de/votesapp/commands/plugins/NameCommentPluginTest.java
@@ -1,0 +1,22 @@
+package de.votesapp.commands.plugins;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+import de.votesapp.client.GroupMessage;
+
+public class NameCommentPluginTest
+{
+    @Test
+    public void should_fetch_comment()
+    {
+        GroupMessage message = mock(GroupMessage.class);
+        when(message.normalizedText()).thenReturn("comment foobar");
+        when(message.getSenderName()).thenReturn("test user");
+        String comment = new NameCommentPlugin().fetchNewComment(message);
+        assertTrue(comment.contains("test user"));
+        assertTrue(comment.contains("foobar"));
+    }
+}


### PR DESCRIPTION
listens for the keyword 'comment' (case insensitive) followed by exactly one word.
responds with an adjective attached to the following word (noun).

eg: message from test user -> comment foobar
response: -> test user says: lonely-foobar